### PR TITLE
Feature/solomon sensu server unique name

### DIFF
--- a/roles/client/files/check-arch3-worker.sh
+++ b/roles/client/files/check-arch3-worker.sh
@@ -1,0 +1,12 @@
+#! /bin/bash
+
+#WORKER_PID=$(cat /var/run/arch3_worker.pid)
+WORKER_PID=$(pgrep -fla java.*Worker | cut -f 1 -d " ")
+if [ -z $WORKER_PID ] ; then
+  echo "Could not pgrep for worker PID"
+  exit 2
+fi
+
+PS_RESULT=$(ps o "%C %x %t %a"  -p)
+echo $PS_RESULT
+exit 0

--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -39,95 +39,95 @@
   gem: name=sensu-plugin state=latest
   when: ansible_distribution_release == "precise"
 
-- name: Install check-procs plugin 
-  get_url: 
-    dest=/etc/sensu/plugins/check-procs.rb 
+- name: Install check-procs plugin
+  get_url:
+    dest=/etc/sensu/plugins/check-procs.rb
     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/processes/check-procs.rb
     mode=755
   notify: restart sensu-client
 
 - name: Install load metrics
-  get_url: 
-    dest=/etc/sensu/plugins/load-metrics.rb 
+  get_url:
+    dest=/etc/sensu/plugins/load-metrics.rb
     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/load-metrics.rb
     mode=755
   notify: restart sensu-client
 
 - name: Install memory metrics
-  get_url: 
-    dest=/etc/sensu/plugins/memory-metrics.rb 
+  get_url:
+    dest=/etc/sensu/plugins/memory-metrics.rb
     url=https://raw.githubusercontent.com/sensu/sensu-community-plugins/master/plugins/system/memory-metrics.rb
     mode=755
   notify: restart sensu-client
 
 - name: Install interface metrics
-  get_url: 
-    dest=/etc/sensu/plugins/interface-metrics.rb 
+  get_url:
+    dest=/etc/sensu/plugins/interface-metrics.rb
     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/interface-metrics.rb
     mode=755
   notify: restart sensu-client
 
 - name: Install disk metrics
-  get_url: 
-    dest=/etc/sensu/plugins/disk-usage-metrics.rb 
+  get_url:
+    dest=/etc/sensu/plugins/disk-usage-metrics.rb
     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/disk-usage-metrics.rb
     mode=755
   notify: restart sensu-client
 
 - name: Install iostat metrics
-  get_url: 
+  get_url:
     dest=/etc/sensu/plugins/iostat-extended-metrics.rb
     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/iostat-extended-metrics.rb
     mode=755
   notify: restart sensu-client
 
-- name: Install check-ntp plugin 
-  get_url: 
-    dest=/etc/sensu/plugins/check-ntp.rb 
+- name: Install check-ntp plugin
+  get_url:
+    dest=/etc/sensu/plugins/check-ntp.rb
     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-ntp.rb
     mode=755
   notify: restart sensu-client
 
-  
-- name: Install check-cmd plugin 
-  get_url: 
-    dest=/etc/sensu/plugins/check-cmd.rb 
+
+- name: Install check-cmd plugin
+  get_url:
+    dest=/etc/sensu/plugins/check-cmd.rb
     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/processes/check-cmd.rb
     mode=755
   notify: restart sensu-client
-  
-- name: Install check-cpu plugin 
-  get_url: 
-    dest=/etc/sensu/plugins/check-cpu.rb 
+
+- name: Install check-cpu plugin
+  get_url:
+    dest=/etc/sensu/plugins/check-cpu.rb
     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-cpu.rb
     mode=755
   notify: restart sensu-client
 
-- name: Install check-fs-writable plugin 
-  get_url: 
-    dest=/etc/sensu/plugins/check-fs-writable.rb 
+- name: Install check-fs-writable plugin
+  get_url:
+    dest=/etc/sensu/plugins/check-fs-writable.rb
     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-fs-writable.rb
     mode=755
   notify: restart sensu-client
 
-- name: Install check-mem plugin 
-  get_url: 
-    dest=/etc/sensu/plugins/check-mem.sh 
+- name: Install check-mem plugin
+  get_url:
+    dest=/etc/sensu/plugins/check-mem.sh
     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-mem.sh
     mode=755
   notify: restart sensu-client
 
 
-- name: Install check-disk-capacity plugin 
-  get_url: 
+- name: Install check-disk-capacity plugin
+  get_url:
     dest=/etc/sensu/plugins/disk-capacity-metrics.rb
     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/disk-capacity-metrics.rb
     mode=755
   notify: restart sensu-client
 
 
-- name: Install check-disk plugin 
-  get_url: 
+- name: Install check-disk plugin
+  get_url:
     dest=/etc/sensu/plugins/check-disk.rb
     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-disk.rb
     mode=755
@@ -149,7 +149,7 @@
   template: src=check-seqware-sanger-jobs-duration.json.j2 dest=/etc/sensu/plugins/check-seqware-sanger-jobs-duration.sh mode=0755
   notify: restart sensu-client
 
-- name: Copy over Gluster peer status check
+- name: Copy over status checks
   copy: src={{ item }} dest=/etc/sensu/plugins/ mode=0755
   with_items:
      - check-gluster.sh
@@ -158,13 +158,21 @@
      - check-sanger.sh
      - check-sge-running-steps.sh
      - check-hdfs.sh
+  notify: restart sensu-client
+
+- name: Copy over checks for Worker node
+  copy: src={{ item }} dest=/etc/sensu/plugins/ mode=0755
+  with_items:
      - check-docker-containers.sh
+     - check-arch3-worker.sh
+  #These two checks should only go on worker nodes.
+  when: 'sensu-server' not in group_names
   notify: restart sensu-client
 
 - name: Activate client services
   service: name={{ item }} state=started enabled=yes
   with_items:
-    - sensu-client 
+    - sensu-client
 
 #- name: Set up the oozie env variable
 #  copy: src=oozie.sh dest=/etc/profile.d/ mode=0755
@@ -184,4 +192,3 @@
 - name: Add sensu user to docker group
   user: name=sensu groups=docker
   when: "'master' in group_names"
-

--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -46,6 +46,16 @@
     mode=755
   notify: restart sensu-client
 
+- name: Install rabbitmq-alive plugin
+  get_url: url=https://raw.githubusercontent.com/sensu/sensu-community-plugins/master/plugins/rabbitmq/rabbitmq-alive.rb dest=/etc/sensu/plugins/rabbitmq-alive.rb mode=755
+  notify: restart sensu-client
+  when: "'arch3-launcher' in {{ subscriptions }}"
+
+- name: Install postgres-alive plugin
+  get_url: url=https://raw.githubusercontent.com/sensu/sensu-community-plugins/master/plugins/postgres/postgres-alive.rb dest=/etc/sensu/plugins/postgres-alive.rb mode=755
+  notify: restart sensu-client
+  when: "'arch3-launcher' in {{ subscriptions }}"
+
 - name: Install load metrics
   get_url:
     dest=/etc/sensu/plugins/load-metrics.rb
@@ -149,24 +159,23 @@
   template: src=check-seqware-sanger-jobs-duration.json.j2 dest=/etc/sensu/plugins/check-seqware-sanger-jobs-duration.sh mode=0755
   notify: restart sensu-client
 
-- name: Copy over status checks
-  copy: src={{ item }} dest=/etc/sensu/plugins/ mode=0755
-  with_items:
-     - check-gluster.sh
-     - check-qstat.sh
-     - check-seqware-failed.sh
-     - check-sanger.sh
-     - check-sge-running-steps.sh
-     - check-hdfs.sh
-  notify: restart sensu-client
+#- name: Copy over status checks
+#  copy: src={{ item }} dest=/etc/sensu/plugins/ mode=0755
+#  with_items:
+#     - check-gluster.sh
+#     - check-qstat.sh
+#     - check-seqware-failed.sh
+#     - check-sanger.sh
+#     - check-sge-running-steps.sh
+#     - check-hdfs.sh
+#  notify: restart sensu-client
 
 - name: Copy over checks for Worker node
   copy: src={{ item }} dest=/etc/sensu/plugins/ mode=0755
   with_items:
      - check-docker-containers.sh
-     - check-arch3-worker.sh
   #These two checks should only go on worker nodes.
-  when: "'sensu-server' not in group_names"
+  when: "'arch3-worker' in {{ subscriptions }}"
   notify: restart sensu-client
 
 - name: Activate client services

--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -39,22 +39,22 @@
   gem: name=sensu-plugin state=latest
   when: ansible_distribution_release == "precise"
 
+- name: Install sensu plugins (and some of their dependencies)
+  gem: name={{ item }} state=latest
+  with_items:
+    - pg
+    - rest_client
+    - sensu-plugins-postgres
+    - sensu-plugins-rabbitmq
+    - sensu-plugins-disk-checks
+    - sensu-plugins-process-checks
+
 - name: Install check-procs plugin
   get_url:
     dest=/etc/sensu/plugins/check-procs.rb
     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/processes/check-procs.rb
     mode=755
   notify: restart sensu-client
-
-- name: Install rabbitmq-alive plugin
-  get_url: url=https://raw.githubusercontent.com/sensu/sensu-community-plugins/master/plugins/rabbitmq/rabbitmq-alive.rb dest=/etc/sensu/plugins/rabbitmq-alive.rb mode=755
-  notify: restart sensu-client
-  when: "'arch3-launcher' in {{ subscriptions }}"
-
-- name: Install postgres-alive plugin
-  get_url: url=https://raw.githubusercontent.com/sensu/sensu-community-plugins/master/plugins/postgres/postgres-alive.rb dest=/etc/sensu/plugins/postgres-alive.rb mode=755
-  notify: restart sensu-client
-  when: "'arch3-launcher' in {{ subscriptions }}"
 
 - name: Install load metrics
   get_url:

--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -166,7 +166,7 @@
      - check-docker-containers.sh
      - check-arch3-worker.sh
   #These two checks should only go on worker nodes.
-  when: 'sensu-server' not in group_names
+  when: "'sensu-server' not in group_names"
   notify: restart sensu-client
 
 - name: Activate client services

--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -48,7 +48,9 @@
     - sensu-plugins-rabbitmq
     - sensu-plugins-disk-checks
     - sensu-plugins-process-checks
+  notify: restart sensu-client
 
+# TODO: Find out if any of the plugins below can now be installed as ruby gems, rather than downloading raw ruby files.
 - name: Install check-procs plugin
   get_url:
     dest=/etc/sensu/plugins/check-procs.rb

--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -36,12 +36,14 @@
   command: gem sources -a https://rubygems.org/
 
 - name: Install sensu-plugin gem
-  gem: name=sensu-plugin state=latest
+  gem: name=sensu-plugin state=latest user_install=no
   when: ansible_distribution_release == "precise"
 
 - name: Install sensu plugins (and some of their dependencies)
-  gem: name={{ item }} state=latest
+  gem: name={{ item }} state=latest include_dependencies=yes user_install=no
   with_items:
+    - rake
+    - bundler
     - pg
     - rest_client
     - sensu-plugins-postgres

--- a/roles/client/templates/client.json.j2
+++ b/roles/client/templates/client.json.j2
@@ -1,6 +1,6 @@
 {
   "client": {
-    "name": "{{ inventory_hostname }}_{{ ansible_ssh_host }}",
+    "name": "{{ fleet_name }}_{{ inventory_hostname }}_{{ ansible_ssh_host }}",
     "address": "{{ ansible_ssh_host }}",
     "subscriptions": [ {{ subscriptions }} ],
     "environment" : {

--- a/roles/client/vars/main.yml
+++ b/roles/client/vars/main.yml
@@ -32,3 +32,4 @@ download_rate_alert: 1000
 # Latest accession used in AWS
 #accession: 21
 workflow_version: SangerPancancerCgpCnIndelSnvStr
+fleet_name: "{{ lookup('env','FLEET_NAME') }}"

--- a/roles/server/templates/checks.json.j2
+++ b/roles/server/templates/checks.json.j2
@@ -4,19 +4,19 @@
       "handlers": ["default"],
       "command": "/etc/sensu/plugins/check-procs.rb -p cron -C 1 ",
       "interval": 60,
-      "subscribers": [ "common" ]
+      "subscribers": [ "deprecated" ]
     },
     "check-glusterfsd": {
       "handlers": ["default"],
       "command": "/etc/sensu/plugins/check-procs.rb -p glusterfsd -C 1 ",
       "interval": 60,
-      "subscribers": [ "multi-node-master", "worker" ]
+      "subscribers": [ "deprecated" ]
     },
     "check-glusterd": {
       "handlers": ["default"],
       "command": "/etc/sensu/plugins/check-procs.rb -p glusterd -C 1 ",
       "interval": 60,
-      "subscribers": [ "multi-node-master", "worker" ]
+      "subscribers": [ "deprecated" ]
     },
     "free_memory_check": {
       "handlers": ["default"],
@@ -35,47 +35,78 @@
       "handlers": ["default"],
       "command": "/etc/sensu/plugins/check-disk.rb ",
       "interval": 60,
-      "subscribers": [ "common", "sanger" ]
+      "subscribers": [ "deprecated" ]
     },
     "check-NFS": {
       "handlers": ["default"],
       "command": "/etc/sensu/plugins/check-procs.rb -p nfsd4 -C 1 ",
       "interval": 60,
-      "subscribers": [ "multi-node-master", "master" ]
+      "subscribers": [ "deprecated" ]
     },
     "gluster_peer_check": {
       "handlers": ["default"],
       "command": "/etc/sensu/plugins/check-gluster.sh",
       "interval": 60,
-      "subscribers": [ "multi-node-master" ]
+      "subscribers": [ "deprecated" ]
     },
     "check-qstat": {
       "handlers": ["default"],
       "command": "/etc/sensu/plugins/check-qstat.sh",
       "interval": 60,
-      "subscribers": [ "multi-node-master", "master" ]
+      "subscribers": [ "deprecated" ]
     },
     "check-hdfs": {
       "handlers": ["default"],
       "command": "/etc/sensu/plugins/check-hdfs.sh",
       "interval": 60,
-      "subscribers": [ "multi-node-master", "sanger" ]
-    },
-    "netapp_check": {
-      "command": "unzip -c /glusterfs/netapp/homes1/BOCONNOR/provisioned-bundles/Workflow_Bundle_BWA_2.6.0_SeqWare_1.0.15/Workflow_Bundle_BWA/2.6.0/bin/jre1.7.0_51/lib/rt.jar > /dev/null",
-      "subscribers": [ "compute" ],
-      "interval": 60
+      "subscribers": [ "deprecated" ]
     },
     "gluster_check": {
       "command": "ls /mnt/glusterfs/data/ICGC1/scratch/seqware_results/ && ls /mnt/glusterfs/data/ICGC2/seqware_results_icgc/completed/ && ls /mnt/glusterfs/data/ICGC3/seqware_results_icgc/completed/",
-      "subscribers": [ "compute" ],
+      "subscribers": [ "deprecated" ],
       "interval": 60
     },
     "docker-check": {
       "handlers":["default"],
       "command":"/etc/sensu/plugins/check-docker-containers.sh",
       "interval":60,
-      "subscribers":["master","docker","common"]
+      "subscribers":["arch3-worker"]
+    },
+    "rabbitmq-alive": {
+      "handlers":["default"],
+      "command":"/etc/sensu/plugins/rabbitmq-alive.rb -w localhost -v / -u queue_user -p queue",
+      "interval":60,
+      "subscribers":["arch3-launcher"]
+    },
+    "postgres-alive": {
+      "handlers":["default"],
+      "command":"/etc/sensu/plugins/postgres-alive.rb -u queue_user -p queue -h localhost -d queue_status",
+      "interval":60,
+      "subscribers":["arch3-launcher"]
+    },
+    "arch3-worker-running": {
+      "handlers": ["default"],
+      "command": "/etc/sensu/plugins/check-procs.rb -p java.*info.pancancer.arch3.worker.Worker -C 1 -c 1",
+      "interval": 60,
+      "subscribers": [ "arch3-worker" ]
+    },
+    "arch3-coordinator-running": {
+      "handlers": ["default"],
+      "command": "/etc/sensu/plugins/check-procs.rb -p java.*info.pancancer.arch3.coordinator.Coordinator -W 1 -w 1",
+      "interval": 60,
+      "subscribers": [ "arch3-launcher" ]
+    },
+    "arch3-provisioner-running": {
+      "handlers": ["default"],
+      "command": "/etc/sensu/plugins/check-procs.rb -p java.*info.pancancer.arch3.containerProvisioner.ContainerProvisionerThreads -W 1 -w 1",
+      "interval": 60,
+      "subscribers": [ "arch3-launcher" ]
+    },
+    "arch3-slack-reporter-running": {
+      "handlers": ["default"],
+      "command": "/etc/sensu/plugins/check-procs.rb -p java.*info.pancancer.arch3.coordinator.Coordinator -W 1 -w 1",
+      "interval": 60,
+      "subscribers": [ "arch3-launcher" ]
     }
   }
 }

--- a/roles/server/templates/checks.json.j2
+++ b/roles/server/templates/checks.json.j2
@@ -74,37 +74,37 @@
     },
     "rabbitmq-alive": {
       "handlers":["default"],
-      "command":"/etc/sensu/plugins/rabbitmq-alive.rb -w localhost -v / -u queue_user -p queue",
+      "command":"check-rabbitmq-alive.rb -w localhost -u queue_user -p queue",
       "interval":60,
       "subscribers":["arch3-launcher"]
     },
     "postgres-alive": {
       "handlers":["default"],
-      "command":"/etc/sensu/plugins/postgres-alive.rb -u queue_user -p queue -h localhost -d queue_status",
+      "command":"check-postgres-alive.rb -u queue_user -p queue -h localhost -d queue_status",
       "interval":60,
       "subscribers":["arch3-launcher"]
     },
     "arch3-worker-running": {
       "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-procs.rb -p java.*info.pancancer.arch3.worker.Worker -C 1 -c 1",
+      "command": "check-process.rb -p java.*info.pancancer.arch3.worker.Worker -C 1 -c 1",
       "interval": 60,
       "subscribers": [ "arch3-worker" ]
     },
     "arch3-coordinator-running": {
       "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-procs.rb -p java.*info.pancancer.arch3.coordinator.Coordinator -W 1 -w 1",
+      "command": "check-process.rb -p java.*info.pancancer.arch3.coordinator.Coordinator -W 1 -w 1",
       "interval": 60,
       "subscribers": [ "arch3-launcher" ]
     },
     "arch3-provisioner-running": {
       "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-procs.rb -p java.*info.pancancer.arch3.containerProvisioner.ContainerProvisionerThreads -W 1 -w 1",
+      "command": "check-process.rb -p java.*info.pancancer.arch3.containerProvisioner.ContainerProvisionerThreads -W 1 -w 1",
       "interval": 60,
       "subscribers": [ "arch3-launcher" ]
     },
     "arch3-slack-reporter-running": {
       "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-procs.rb -p java.*info.pancancer.arch3.coordinator.Coordinator -W 1 -w 1",
+      "command": "check-process.rb -p java.*info.pancancer.arch3.reportbot.SlackReportBot -W 1 -w 1",
       "interval": 60,
       "subscribers": [ "arch3-launcher" ]
     }

--- a/site.yml
+++ b/site.yml
@@ -29,25 +29,25 @@
     - { role: server }
     - { role: sensu-cli }
     - { role: uchiwa }
-    - { role: client, subscriptions: "\"common\"" }
+    - { role: client, subscriptions: "\"common\",\"arch3-launcher\"" }
 
 - hosts: worker
   sudo: True
   roles:
     - { role: base }
-    - { role: client, subscriptions: "\"common\",\"compute\"" }
+    - { role: client, subscriptions: "\"common\",\"compute\",\"docker\",\"arch3-worker\"" }
 
-- hosts: multi-node-master
-  sudo: True
-  roles:
-    - { role: base }
-    - { role: client, subscriptions: "\"common\",\"multi-node-master\"" }
+#- hosts: multi-node-master
+#  sudo: True
+#  roles:
+#    - { role: base }
+#    - { role: client, subscriptions: "\"common\",\"multi-node-master\"" }
 
-- hosts: master
-  sudo: True
-  roles:
-    - { role: base }
-    - { role: client, subscriptions: "\"common\",\"sanger\"" }
+#- hosts: master
+#  sudo: True
+#  roles:
+#    - { role: base }
+#    - { role: client, subscriptions: "\"common\",\"sanger\"" }
 
 #- hosts: master
 #  sudo: True


### PR DESCRIPTION
Assign a fleet name to sensu servers so that they will not all appear as "sensu-server_localhost" in the centralized monitoring dashboard. Also some new sensu checks for Architecture3.