### PR TITLE
Feature/switch to newer plugins

### DIFF
--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -48,6 +48,9 @@
   gem: name=sensu-plugin state=latest user_install=no
   when: ansible_distribution_release == "precise"
 
+- name: Install gem sys-filesystem
+  gem: name=sys-filesystem state=latest user_install=no
+
 - name: Install sensu plugins (and some of their dependencies)
   gem: name={{ item }} state=latest user_install=no
   with_items:

--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -48,12 +48,13 @@
   gem: name=sensu-plugin state=latest user_install=no
   when: ansible_distribution_release == "precise"
 
-- name: Install gem sys-filesystem
-  gem: name=sys-filesystem state=latest user_install=no
+#- name: Install gem sys-filesystem
+#  gem: name=sys-filesystem state=latest user_install=no
 
 - name: Install sensu plugins (and some of their dependencies)
   gem: name={{ item }} state=latest user_install=no
   with_items:
+    - sys-filesystem
     - rake
     - bundler
     - pg
@@ -72,101 +73,6 @@
     - sensu-plugins-disk-checks
   notify: restart sensu-client
 
-# TODO: Find out if any of the plugins below can now be installed as ruby gems, rather than downloading raw ruby files.
-# - name: Install check-procs plugin
-#   get_url:
-#     dest=/etc/sensu/plugins/check-procs.rb
-#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/processes/check-procs.rb
-#     mode=755
-#   notify: restart sensu-client
-
-# - name: Install load metrics
-#   get_url:
-#     dest=/etc/sensu/plugins/load-metrics.rb
-#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/load-metrics.rb
-#     mode=755
-#   notify: restart sensu-client
-
-# - name: Install memory metrics
-#   get_url:
-#     dest=/etc/sensu/plugins/memory-metrics.rb
-#     url=https://raw.githubusercontent.com/sensu/sensu-community-plugins/master/plugins/system/memory-metrics.rb
-#     mode=755
-#   notify: restart sensu-client
-
-# - name: Install interface metrics
-#   get_url:
-#     dest=/etc/sensu/plugins/interface-metrics.rb
-#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/interface-metrics.rb
-#     mode=755
-#   notify: restart sensu-client
-
-# - name: Install disk metrics
-#   get_url:
-#     dest=/etc/sensu/plugins/disk-usage-metrics.rb
-#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/disk-usage-metrics.rb
-#     mode=755
-#   notify: restart sensu-client
-
-# - name: Install iostat metrics
-#   get_url:
-#     dest=/etc/sensu/plugins/iostat-extended-metrics.rb
-#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/iostat-extended-metrics.rb
-#     mode=755
-#   notify: restart sensu-client
-
-# - name: Install check-ntp plugin
-#   get_url:
-#     dest=/etc/sensu/plugins/check-ntp.rb
-#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-ntp.rb
-#     mode=755
-#   notify: restart sensu-client
-
-
-# - name: Install check-cmd plugin
-#   get_url:
-#     dest=/etc/sensu/plugins/check-cmd.rb
-#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/processes/check-cmd.rb
-#     mode=755
-#   notify: restart sensu-client
-
-# - name: Install check-cpu plugin
-#   get_url:
-#     dest=/etc/sensu/plugins/check-cpu.rb
-#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-cpu.rb
-#     mode=755
-#   notify: restart sensu-client
-
-# - name: Install check-fs-writable plugin
-#   get_url:
-#     dest=/etc/sensu/plugins/check-fs-writable.rb
-#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-fs-writable.rb
-#     mode=755
-#   notify: restart sensu-client
-
-# - name: Install check-mem plugin
-#   get_url:
-#     dest=/etc/sensu/plugins/check-mem.sh
-#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-mem.sh
-#     mode=755
-#   notify: restart sensu-client
-
-#
-# - name: Install check-disk-capacity plugin
-#   get_url:
-#     dest=/etc/sensu/plugins/disk-capacity-metrics.rb
-#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/disk-capacity-metrics.rb
-#     mode=755
-#   notify: restart sensu-client
-
-
-# - name: Install check-disk plugin
-#   get_url:
-#     dest=/etc/sensu/plugins/check-disk.rb
-#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-disk.rb
-#     mode=755
-#   notify: restart sensu-client
-
 - name: Template over check-seqware-running.sh
   template: src=check-seqware-running.json.j2 dest=/etc/sensu/plugins/check-seqware-running.sh mode=0755
   notify: restart sensu-client
@@ -183,22 +89,11 @@
   template: src=check-seqware-sanger-jobs-duration.json.j2 dest=/etc/sensu/plugins/check-seqware-sanger-jobs-duration.sh mode=0755
   notify: restart sensu-client
 
-#- name: Copy over status checks
-#  copy: src={{ item }} dest=/etc/sensu/plugins/ mode=0755
-#  with_items:
-#     - check-gluster.sh
-#     - check-qstat.sh
-#     - check-seqware-failed.sh
-#     - check-sanger.sh
-#     - check-sge-running-steps.sh
-#     - check-hdfs.sh
-#  notify: restart sensu-client
-
 - name: Copy over checks for Worker node
   copy: src={{ item }} dest=/etc/sensu/plugins/ mode=0755
   with_items:
      - check-docker-containers.sh
-  #These two checks should only go on worker nodes.
+  #These checks should only go on worker nodes.
   when: "'arch3-worker' in {{ subscriptions }}"
   notify: restart sensu-client
 
@@ -207,20 +102,9 @@
   with_items:
     - sensu-client
 
-#- name: Set up the oozie env variable
-#  copy: src=oozie.sh dest=/etc/profile.d/ mode=0755
-
 - name: Check if Seqware is installed on this machine
   command: ls /home
   register: home_output
-
-#- name: Copy over the script that restarts oozie in case is out-of-sync with SGE
-#  copy: src=test_oozie_sge.pl  dest=/mnt/home/seqware mode=0755
-#  when: home_output.stdout.find('seqware') != -1
-
-#- name: Creates a cron job that runs every 30 min and executes the oozie restart script
-#  cron: name="restart oozie" minute="*/30" hour="*" user=seqware job="perl /mnt/home/seqware/test_oozie_sge.pl > /dev/null"
-#  when: home_output.stdout.find('seqware') != -1
 
 - name: Add sensu user to docker group
   user: name=sensu groups=docker

--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -59,102 +59,110 @@
     - sensu-plugins-rabbitmq
     - sensu-plugins-disk-checks
     - sensu-plugins-process-checks
+    - sensu-plugins-load-checks
+    - sensu-plugins-memory-checks
+    - sensu-plugins-network-checks
+    - sensu-plugins-io-checks
+    - sensu-plugins-ntp
+    - sensu-plugins-cpu-checks
+    - sensu-plugins-filesystem-checks
+    - sensu-plugins-disk-checks
   notify: restart sensu-client
 
 # TODO: Find out if any of the plugins below can now be installed as ruby gems, rather than downloading raw ruby files.
-- name: Install check-procs plugin
-  get_url:
-    dest=/etc/sensu/plugins/check-procs.rb
-    url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/processes/check-procs.rb
-    mode=755
-  notify: restart sensu-client
+# - name: Install check-procs plugin
+#   get_url:
+#     dest=/etc/sensu/plugins/check-procs.rb
+#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/processes/check-procs.rb
+#     mode=755
+#   notify: restart sensu-client
 
-- name: Install load metrics
-  get_url:
-    dest=/etc/sensu/plugins/load-metrics.rb
-    url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/load-metrics.rb
-    mode=755
-  notify: restart sensu-client
+# - name: Install load metrics
+#   get_url:
+#     dest=/etc/sensu/plugins/load-metrics.rb
+#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/load-metrics.rb
+#     mode=755
+#   notify: restart sensu-client
 
-- name: Install memory metrics
-  get_url:
-    dest=/etc/sensu/plugins/memory-metrics.rb
-    url=https://raw.githubusercontent.com/sensu/sensu-community-plugins/master/plugins/system/memory-metrics.rb
-    mode=755
-  notify: restart sensu-client
+# - name: Install memory metrics
+#   get_url:
+#     dest=/etc/sensu/plugins/memory-metrics.rb
+#     url=https://raw.githubusercontent.com/sensu/sensu-community-plugins/master/plugins/system/memory-metrics.rb
+#     mode=755
+#   notify: restart sensu-client
 
-- name: Install interface metrics
-  get_url:
-    dest=/etc/sensu/plugins/interface-metrics.rb
-    url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/interface-metrics.rb
-    mode=755
-  notify: restart sensu-client
+# - name: Install interface metrics
+#   get_url:
+#     dest=/etc/sensu/plugins/interface-metrics.rb
+#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/interface-metrics.rb
+#     mode=755
+#   notify: restart sensu-client
 
-- name: Install disk metrics
-  get_url:
-    dest=/etc/sensu/plugins/disk-usage-metrics.rb
-    url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/disk-usage-metrics.rb
-    mode=755
-  notify: restart sensu-client
+# - name: Install disk metrics
+#   get_url:
+#     dest=/etc/sensu/plugins/disk-usage-metrics.rb
+#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/disk-usage-metrics.rb
+#     mode=755
+#   notify: restart sensu-client
 
-- name: Install iostat metrics
-  get_url:
-    dest=/etc/sensu/plugins/iostat-extended-metrics.rb
-    url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/iostat-extended-metrics.rb
-    mode=755
-  notify: restart sensu-client
+# - name: Install iostat metrics
+#   get_url:
+#     dest=/etc/sensu/plugins/iostat-extended-metrics.rb
+#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/iostat-extended-metrics.rb
+#     mode=755
+#   notify: restart sensu-client
 
-- name: Install check-ntp plugin
-  get_url:
-    dest=/etc/sensu/plugins/check-ntp.rb
-    url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-ntp.rb
-    mode=755
-  notify: restart sensu-client
-
-
-- name: Install check-cmd plugin
-  get_url:
-    dest=/etc/sensu/plugins/check-cmd.rb
-    url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/processes/check-cmd.rb
-    mode=755
-  notify: restart sensu-client
-
-- name: Install check-cpu plugin
-  get_url:
-    dest=/etc/sensu/plugins/check-cpu.rb
-    url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-cpu.rb
-    mode=755
-  notify: restart sensu-client
-
-- name: Install check-fs-writable plugin
-  get_url:
-    dest=/etc/sensu/plugins/check-fs-writable.rb
-    url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-fs-writable.rb
-    mode=755
-  notify: restart sensu-client
-
-- name: Install check-mem plugin
-  get_url:
-    dest=/etc/sensu/plugins/check-mem.sh
-    url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-mem.sh
-    mode=755
-  notify: restart sensu-client
+# - name: Install check-ntp plugin
+#   get_url:
+#     dest=/etc/sensu/plugins/check-ntp.rb
+#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-ntp.rb
+#     mode=755
+#   notify: restart sensu-client
 
 
-- name: Install check-disk-capacity plugin
-  get_url:
-    dest=/etc/sensu/plugins/disk-capacity-metrics.rb
-    url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/disk-capacity-metrics.rb
-    mode=755
-  notify: restart sensu-client
+# - name: Install check-cmd plugin
+#   get_url:
+#     dest=/etc/sensu/plugins/check-cmd.rb
+#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/processes/check-cmd.rb
+#     mode=755
+#   notify: restart sensu-client
+
+# - name: Install check-cpu plugin
+#   get_url:
+#     dest=/etc/sensu/plugins/check-cpu.rb
+#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-cpu.rb
+#     mode=755
+#   notify: restart sensu-client
+
+# - name: Install check-fs-writable plugin
+#   get_url:
+#     dest=/etc/sensu/plugins/check-fs-writable.rb
+#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-fs-writable.rb
+#     mode=755
+#   notify: restart sensu-client
+
+# - name: Install check-mem plugin
+#   get_url:
+#     dest=/etc/sensu/plugins/check-mem.sh
+#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-mem.sh
+#     mode=755
+#   notify: restart sensu-client
+
+#
+# - name: Install check-disk-capacity plugin
+#   get_url:
+#     dest=/etc/sensu/plugins/disk-capacity-metrics.rb
+#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/disk-capacity-metrics.rb
+#     mode=755
+#   notify: restart sensu-client
 
 
-- name: Install check-disk plugin
-  get_url:
-    dest=/etc/sensu/plugins/check-disk.rb
-    url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-disk.rb
-    mode=755
-  notify: restart sensu-client
+# - name: Install check-disk plugin
+#   get_url:
+#     dest=/etc/sensu/plugins/check-disk.rb
+#     url=https://raw.github.com/sensu/sensu-community-plugins/master/plugins/system/check-disk.rb
+#     mode=755
+#   notify: restart sensu-client
 
 - name: Template over check-seqware-running.sh
   template: src=check-seqware-running.json.j2 dest=/etc/sensu/plugins/check-seqware-running.sh mode=0755

--- a/roles/client/tasks/main.yml
+++ b/roles/client/tasks/main.yml
@@ -102,10 +102,6 @@
   with_items:
     - sensu-client
 
-- name: Check if Seqware is installed on this machine
-  command: ls /home
-  register: home_output
-
 - name: Add sensu user to docker group
   user: name=sensu groups=docker
   when: "'master' in group_names"

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -17,25 +17,25 @@
   template: src=checks.json.j2 dest=/etc/sensu/conf.d/checks.json
   notify: restart sensu server services
 
-- name: Disk usage metrics
-  template: src=disk-usage-metrics.json.j2 dest=/etc/sensu/conf.d/disk-usage-metrics.json
-  notify: restart sensu server services
+# - name: Disk usage metrics
+#   template: src=disk-usage-metrics.json.j2 dest=/etc/sensu/conf.d/disk-usage-metrics.json
+#   notify: restart sensu server services
 
-- name: CPU load metrics
-  template: src=load-metrics.json.j2 dest=/etc/sensu/conf.d/load-metrics.json
-  notify: restart sensu server services
+# - name: CPU load metrics
+#   template: src=load-metrics.json.j2 dest=/etc/sensu/conf.d/load-metrics.json
+#   notify: restart sensu server services
 
-- name: Interface metrics
-  template: src=interface-metrics.json.j2 dest=/etc/sensu/conf.d/interface-metrics.json
-  notify: restart sensu server services
+# - name: Interface metrics
+#   template: src=interface-metrics.json.j2 dest=/etc/sensu/conf.d/interface-metrics.json
+#   notify: restart sensu server services
 
-- name: Memory usage metrics
-  template: src=memory-metrics.json.j2 dest=/etc/sensu/conf.d/memory-metrics.json
-  notify: restart sensu server services
+# - name: Memory usage metrics
+#   template: src=memory-metrics.json.j2 dest=/etc/sensu/conf.d/memory-metrics.json
+#   notify: restart sensu server services
 
-- name:  Iostat metrics
-  template: src=iostat-extended-metrics.json.j2 dest=/etc/sensu/conf.d/iostat-extended-metrics.json
-  notify: restart sensu server services
+# - name:  Iostat metrics
+#   template: src=iostat-extended-metrics.json.j2 dest=/etc/sensu/conf.d/iostat-extended-metrics.json
+#   notify: restart sensu server services
 
 - name: Ensure state of server services
   sudo: True

--- a/roles/server/tasks/main.yml
+++ b/roles/server/tasks/main.yml
@@ -17,26 +17,6 @@
   template: src=checks.json.j2 dest=/etc/sensu/conf.d/checks.json
   notify: restart sensu server services
 
-# - name: Disk usage metrics
-#   template: src=disk-usage-metrics.json.j2 dest=/etc/sensu/conf.d/disk-usage-metrics.json
-#   notify: restart sensu server services
-
-# - name: CPU load metrics
-#   template: src=load-metrics.json.j2 dest=/etc/sensu/conf.d/load-metrics.json
-#   notify: restart sensu server services
-
-# - name: Interface metrics
-#   template: src=interface-metrics.json.j2 dest=/etc/sensu/conf.d/interface-metrics.json
-#   notify: restart sensu server services
-
-# - name: Memory usage metrics
-#   template: src=memory-metrics.json.j2 dest=/etc/sensu/conf.d/memory-metrics.json
-#   notify: restart sensu server services
-
-# - name:  Iostat metrics
-#   template: src=iostat-extended-metrics.json.j2 dest=/etc/sensu/conf.d/iostat-extended-metrics.json
-#   notify: restart sensu server services
-
 - name: Ensure state of server services
   sudo: True
   service: name={{ item }} state=started enabled=yes

--- a/roles/server/templates/checks.json.j2
+++ b/roles/server/templates/checks.json.j2
@@ -45,9 +45,9 @@
       "subscribers": [ "common" ],
       "handlers": ["relay"]
     },
-    "disk-capacity": {
+    "disk-usage-metrics": {
       "handlers": ["default"],
-      "command": "metrics-disk-capacity.rb",
+      "command": "metrics-disk-usage.rb",
       "interval": 60,
       "subscribers": [ "common" ]
     },

--- a/roles/server/templates/checks.json.j2
+++ b/roles/server/templates/checks.json.j2
@@ -1,26 +1,9 @@
 {
   "checks": {
-    "cron_check": {
-      "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-procs.rb -p cron -C 1 ",
-      "interval": 60,
-      "subscribers": [ "deprecated" ]
-    },
-    "check-glusterfsd": {
-      "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-procs.rb -p glusterfsd -C 1 ",
-      "interval": 60,
-      "subscribers": [ "deprecated" ]
-    },
-    "check-glusterd": {
-      "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-procs.rb -p glusterd -C 1 ",
-      "interval": 60,
-      "subscribers": [ "deprecated" ]
-    },
+
     "free_memory_check": {
       "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-mem.sh -w 800 -c 500 ",
+      "command": "/etc/sensu/plugins/check-memory.sh -w 800 -c 500 ",
       "interval": 60,
       "subscribers": [ "common" ]
     },
@@ -31,40 +14,17 @@
       "occurrences": 3,
       "subscribers": [ "common" ]
     },
-    "check-disk-space": {
+    "check-disk-space-usage": {
       "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-disk.rb ",
+      "command": "/etc/sensu/plugins/check-disk-usage.rb -c 90 -w 75",
       "interval": 60,
-      "subscribers": [ "deprecated" ]
+      "subscribers": [ "common" ]
     },
-    "check-NFS": {
+    "disk-capacity": {
       "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-procs.rb -p nfsd4 -C 1 ",
+      "command": "metrics-disk-capacity.rb",
       "interval": 60,
-      "subscribers": [ "deprecated" ]
-    },
-    "gluster_peer_check": {
-      "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-gluster.sh",
-      "interval": 60,
-      "subscribers": [ "deprecated" ]
-    },
-    "check-qstat": {
-      "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-qstat.sh",
-      "interval": 60,
-      "subscribers": [ "deprecated" ]
-    },
-    "check-hdfs": {
-      "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-hdfs.sh",
-      "interval": 60,
-      "subscribers": [ "deprecated" ]
-    },
-    "gluster_check": {
-      "command": "ls /mnt/glusterfs/data/ICGC1/scratch/seqware_results/ && ls /mnt/glusterfs/data/ICGC2/seqware_results_icgc/completed/ && ls /mnt/glusterfs/data/ICGC3/seqware_results_icgc/completed/",
-      "subscribers": [ "deprecated" ],
-      "interval": 60
+      "subscribers": [ "common" ]
     },
     "docker-check": {
       "handlers":["default"],

--- a/roles/server/templates/checks.json.j2
+++ b/roles/server/templates/checks.json.j2
@@ -26,6 +26,12 @@
       "interval": 60,
       "subscribers": [ "common" ]
     },
+    "interface-check": {
+      "handlers":["default"],
+      "command":"metrics-interface.rb",
+      "interval":60,
+      "subscribers":["common"]
+    },
     "docker-check": {
       "handlers":["default"],
       "command":"/etc/sensu/plugins/check-docker-containers.sh",

--- a/roles/server/templates/checks.json.j2
+++ b/roles/server/templates/checks.json.j2
@@ -12,21 +12,24 @@
       "command": "metrics-load.rb --per-core",
       "interval": 60,
       "occurrences": 3,
-      "subscribers": [ "common" ]
+      "subscribers": [ "common" ],
+      "handlers": ["relay"]
     },
     "iostat-metrics": {
       "handlers": ["default"],
       "command": "metrics-iostat-extended.rb",
       "interval": 60,
       "occurrences": 3,
-      "subscribers": [ "common" ]
+      "subscribers": [ "common" ],
+      "handlers": ["relay"]
     },
     "memory-metrics": {
       "handlers": ["default"],
       "command": "metrics-load.rb --per-core",
       "interval": 60,
       "occurrences": 3,
-      "subscribers": [ "common" ]
+      "subscribers": [ "common" ],
+      "handlers": ["relay"]
     },
     "cpu-load": {
       "handlers": ["default"],
@@ -39,7 +42,8 @@
       "handlers": ["default"],
       "command": "check-disk-usage.rb -c 90 -w 75",
       "interval": 60,
-      "subscribers": [ "common" ]
+      "subscribers": [ "common" ],
+      "handlers": ["relay"]
     },
     "disk-capacity": {
       "handlers": ["default"],
@@ -51,7 +55,8 @@
       "handlers":["default"],
       "command":"metrics-interface.rb",
       "interval":60,
-      "subscribers":["common"]
+      "subscribers":["common"],
+      "handlers": ["relay"]
     },
     "docker-check": {
       "handlers":["default"],

--- a/roles/server/templates/checks.json.j2
+++ b/roles/server/templates/checks.json.j2
@@ -1,7 +1,7 @@
 
 {
   "checks": {
-    "free-memory-check": {
+    "check-free-memory": {
       "handlers": ["default"],
       "command": "check-ram.rb -c 80 -w 50 ",
       "interval": 60,
@@ -25,13 +25,13 @@
     },
     "memory-metrics": {
       "handlers": ["default"],
-      "command": "metrics-load.rb --per-core",
+      "command": "metrics-memory.rb",
       "interval": 60,
       "occurrences": 3,
       "subscribers": [ "common" ],
       "handlers": ["relay"]
     },
-    "cpu-load": {
+    "check-cpu": {
       "handlers": ["default"],
       "command": "check-cpu.rb -w 90 -c 110 ",
       "interval": 60,
@@ -51,14 +51,14 @@
       "interval": 60,
       "subscribers": [ "common" ]
     },
-    "interface-check": {
+    "interface-metrics": {
       "handlers":["default"],
       "command":"metrics-interface.rb",
       "interval":60,
       "subscribers":["common"],
       "handlers": ["relay"]
     },
-    "docker-check": {
+    "check-docker": {
       "handlers":["default"],
       "command":"/etc/sensu/plugins/check-docker-containers.sh",
       "interval":60,

--- a/roles/server/templates/checks.json.j2
+++ b/roles/server/templates/checks.json.j2
@@ -1,22 +1,43 @@
+
 {
   "checks": {
-
-    "free_memory_check": {
+    "free-memory-check": {
       "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-memory.sh -w 800 -c 500 ",
+      "command": "check-ram.rb -c 80 -w 50 ",
       "interval": 60,
       "subscribers": [ "common" ]
     },
-    "cpu_load": {
+    "load-metrics": {
       "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-cpu.rb -w 90 -c 110 ",
+      "command": "metrics-load.rb --per-core",
+      "interval": 60,
+      "occurrences": 3,
+      "subscribers": [ "common" ]
+    },
+    "iostat-metrics": {
+      "handlers": ["default"],
+      "command": "metrics-iostat-extended.rb",
+      "interval": 60,
+      "occurrences": 3,
+      "subscribers": [ "common" ]
+    },
+    "memory-metrics": {
+      "handlers": ["default"],
+      "command": "metrics-load.rb --per-core",
+      "interval": 60,
+      "occurrences": 3,
+      "subscribers": [ "common" ]
+    },
+    "cpu-load": {
+      "handlers": ["default"],
+      "command": "check-cpu.rb -w 90 -c 110 ",
       "interval": 60,
       "occurrences": 3,
       "subscribers": [ "common" ]
     },
     "check-disk-space-usage": {
       "handlers": ["default"],
-      "command": "/etc/sensu/plugins/check-disk-usage.rb -c 90 -w 75",
+      "command": "check-disk-usage.rb -c 90 -w 75",
       "interval": 60,
       "subscribers": [ "common" ]
     },


### PR DESCRIPTION
Old sensu-plugins were removed from github. They must now be installed as ruby gems.
